### PR TITLE
Reduce backward memory to ~half

### DIFF
--- a/include/inplace_abn.h
+++ b/include/inplace_abn.h
@@ -132,8 +132,8 @@ struct ActivationFn<scalar_t, Activation::ELU> {
       y = y_act;
       dy = dy_act;
     } else {
-      y = ::log1p(static_cast<scalar_t>(y_act / activation_param));
       dy = static_cast<scalar_t>(dy_act * (y_act + activation_param));
+      y = ::log1p(static_cast<scalar_t>(y_act / activation_param));
     }
   }
 };

--- a/inplace_abn/functions.py
+++ b/inplace_abn/functions.py
@@ -115,9 +115,11 @@ class InPlaceABN(autograd.Function):
     @once_differentiable
     def backward(ctx, dy_act):
         y_act, var, count, weight, bias = ctx.saved_tensors
-
         # Call backward_reduce if we need to compute at least one of the gradients
         if any(ctx.needs_input_grad):
+            # remove memory overlaping to allow for in-place operation
+            dy_act = dy_act.contiguous()
+            # This overwrites y_act with xhat and dy_act with dy
             xhat, dy, sum_dy_local, sum_xhat_dy_local = _backend.backward_reduce(
                 y_act,
                 dy_act,

--- a/src/inplace_abn.cpp
+++ b/src/inplace_abn.cpp
@@ -224,7 +224,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       "iABN forward pass. This is an in-place operation w.r.t. x");
 
   // Backward methods
-  m.def("backward_reduce", &backward_reduce, "First step of the backward pass");
+  m.def("backward_reduce", &backward_reduce, "First step of the backward pass. This is an in-place operation w.r.t. y_act, dy_act,");
   m.def(
       "backward_train",
       &backward_train,

--- a/src/inplace_abn_cuda.cu
+++ b/src/inplace_abn_cuda.cu
@@ -143,8 +143,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor> backward_reduce_templ
   }
 
   // Initialize output tensors
-  auto xhat = at::empty_like(y_act);
-  auto dy = at::empty_like(y_act);
+  auto &xhat = y_act; // reuse
+  auto &dy = dy_act; // reuse
   auto sum_dy = at::empty({chn}, acc_options);
   auto sum_xhat_dy = at::empty({chn}, acc_options);
 


### PR DESCRIPTION
Reuse the grad and input tensors in the backward pass instead of creating new ones.
Mainly reuse `y_act` for `xhat` and `dy_act` for `dy`.
Ensure every function support in-place operation. (Elu is modified accordingly)
Ensure the tensors allow in-place operation (`dy_act` has to be contiguous)

Needs more testing. However, there are no unit tests.