### PR TITLE
Fix svg figure to LaTex in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ training time.
 To achieve this, we rewrite the backward pass of BN in terms of its output `y`, which is in turn reconstructed from `z`
 by inverting the activation function.
 
-The parametrization for the scaling factor of BN changed compared to standard BN, in order to ensure an invertible transformation. Specifically, the scaling factor becomes
-<img src="./equation.svg">.
+The parametrization for the scaling factor of BN changed compared to standard BN, in order to ensure an invertible transformation. Specifically, the scaling factor becomes $\hat{\gamma} = \left | \gamma \right | + \epsilon$ .
 
 ## Requirements
 


### PR DESCRIPTION
At the end of the Overview, the formula is barely visible due to the similarity of the background and the font color. Furthermore, the current version of GIthub supports LaTex representation so it's clearer to see the formula if you replace the svg file with LaTex text.